### PR TITLE
Category attributes in valid xml that is FixMyStreet friendly

### DIFF
--- a/codeigniter/fms_endpoint/views/category_attributes_xml.php
+++ b/codeigniter/fms_endpoint/views/category_attributes_xml.php
@@ -7,10 +7,11 @@ $dom = xml_dom();
 $service_definition = xml_add_child($dom, 'service_definition');
 
 	$service_code = xml_add_child($service_definition, 'service_code', $category_id);
+	$attributes_container = xml_add_child($service_definition, 'attributes');
 
 	foreach($attributes->result() as $row) {
 
-	$attribute = xml_add_child($service_definition, 'attribute');
+	$attribute = xml_add_child($attributes_container, 'attribute');
 
 	xml_add_child($attribute, 'variable', $row->variable);
 	xml_add_child($attribute, 'code', $row->attribute_id);

--- a/codeigniter/fms_endpoint/views/category_attributes_xml.php
+++ b/codeigniter/fms_endpoint/views/category_attributes_xml.php
@@ -20,8 +20,10 @@ $service_definition = xml_add_child($dom, 'service_definition');
 	xml_add_child($attribute, 'datatype_description', $row->datatype_description);
 	xml_add_child($attribute, 'order', $row->order);
 	xml_add_child($attribute, 'description', $row->description);
-	xml_add_child($attribute, 'values', $row->values);	
+	if (strlen($row->values) > 0){
+		xml_add_child($attribute, 'values', $row->values);	
 
+	}
 	}
 
 xml_print($dom);


### PR DESCRIPTION
A couple of small commits on the `category_attributes_xml` view that prompts FixMyStreet to ask the user for additional information specific to a problem type. In the case of abandoned vehicle reporting for example, collecting registration, make and model, and colour up front helps to progress an investigation. 